### PR TITLE
Update belt.json to include Arcane Lanterns

### DIFF
--- a/src/generated/resources/data/curios/tags/items/belt.json
+++ b/src/generated/resources/data/curios/tags/items/belt.json
@@ -3415,6 +3415,46 @@
     {
       "id": "additionallanterns:black_weathered_copper_lantern",
       "required": false
+    },
+    {
+      "id": "arcanelanterns:boreal_lantern",
+      "required": false
+    },
+    {
+      "id": "arcanelanterns:brilliant_lantern",
+      "required": false
+    },
+    {
+      "id": "arcanelanterns:cloud_lantern",
+      "required": false
+    },
+    {
+      "id": "arcanelanterns:containing_lantern",
+      "required": false
+    },
+    {
+      "id": "arcanelanterns:feral_lantern",
+      "required": false
+    },
+    {
+      "id": "arcanelanterns:life_lantern",
+      "required": false
+    },
+    {
+      "id": "arcanelanterns:love_lantern",
+      "required": false
+    },
+    {
+      "id": "arcanelanterns:wailing_lantern",
+      "required": false
+    },
+    {
+      "id": "arcanelanterns:warding_lantern",
+      "required": false
+    },
+    {
+      "id": "arcanelanterns:withering_lantern",
+      "required": false
     }
   ]
 }


### PR DESCRIPTION
All additions are at the bottom of the list, please double check arcanelanterns:feral_lantern, as it may result in some issues since Arcane Lanterns seems to list it as "minecraft:lantern" as an item, but then lists it as arcanelanterns:feral_lantern as a block. I do not know much about java, so I don't know if this would cause issues.